### PR TITLE
Fix configuration value filtering

### DIFF
--- a/langgraph_templates/src/memory_agent/configuration.py
+++ b/langgraph_templates/src/memory_agent/configuration.py
@@ -39,4 +39,4 @@ class Configuration:
             if f.init
         }
 
-        return cls(**{k: v for k, v in values.items() if v})
+        return cls(**{k: v for k, v in values.items() if v is not None})

--- a/langgraph_templates/src/memory_agent/graph.py
+++ b/langgraph_templates/src/memory_agent/graph.py
@@ -30,7 +30,9 @@ async def call_model(state: State, config: RunnableConfig, *, store: BaseStore) 
     )
 
     # Format memories for inclusion in the prompt
-    formatted = "\n".join(f"[{mem.key}]: {mem.value} (similarity: {mem.score})" for mem in memories)
+    formatted = "\n".join(
+        f"[{mem.key}]: {mem.value} (similarity: {mem.score})" for mem in memories
+    )
     if formatted:
         formatted = f"""
 <memories>

--- a/langgraph_templates/src/memory_agent/tools.py
+++ b/langgraph_templates/src/memory_agent/tools.py
@@ -1,4 +1,4 @@
-"""Define he agent's tools."""
+"""Define the agent's tools."""
 
 import uuid
 from typing import Annotated, Optional


### PR DESCRIPTION
## Summary
- keep falsy configuration values instead of discarding them
- tweak formatting in `graph.py`
- fix typo in tools module docstring

## Testing
- `make lint`
- `make test` *(fails: No module named pytest)*