### PR TITLE
Update langgraph version for compatibility

### DIFF
--- a/langgraph_templates/pyproject.toml
+++ b/langgraph_templates/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.9"
 dependencies = [
-    "langgraph>=0.2.34,<0.3.0",
+    "langgraph>=0.4.5,<0.5.0",
     # Optional (for selecting different models)
     "langchain-openai>=0.2.1",
     "langchain-anthropic>=0.2.1",


### PR DESCRIPTION
## Summary
- bump `langgraph` version to >=0.4.5,<0.5.0

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*